### PR TITLE
fix: invert pwm command instead of effort cmd

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -65,14 +65,7 @@ uint32_t Task::computePWMCommand(float command) const
 
 uint32_t Task::invertPWMCommand(uint32_t pwm_command) const
 {
-    const auto& lut = m_cmd_to_pwm_lut;
-    uint32_t lut_center =
-        (lut.duty_cycle_width.back() + lut.duty_cycle_width.front()) / 2;
-    auto cmd_distance_from_center = abs(lut_center - pwm_command);
-    if (pwm_command < lut_center) {
-        return pwm_command + 2 * cmd_distance_from_center;
-    }
-    return pwm_command - 2 * cmd_distance_from_center;
+    return m_lut_center_duty_cycle - (pwm_command - m_lut_center_duty_cycle);
 }
 
 /// The following lines are template definitions for the various state machine
@@ -84,6 +77,7 @@ bool Task::configureHook()
     if (!TaskBase::configureHook())
         return false;
 
+    m_lut_center_duty_cycle = _center_duty_cycle.get();
     m_no_actuation_pwm_command = _no_actuation_pwm_command.get();
     m_cmd_in_mode = _cmd_in_mode.get();
     auto const helices_alignment = _helices_alignment.get();
@@ -93,7 +87,6 @@ bool Task::configureHook()
         m_helices_alignment.emplace_back(static_cast<int>(alignment));
     }
     m_cmd_to_pwm_lut = loadCommandToPWMTable(_command_to_pwm_table_file_path.get());
-
     return true;
 }
 bool Task::startHook()

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -41,6 +41,7 @@ namespace thrusters_blue_robotics_t500 {
 
         // Properties
         std::uint32_t m_no_actuation_pwm_command = 1500;
+        float m_lut_center_duty_cycle = 1500000;
         base::JointState::MODE m_cmd_in_mode;
 
         PWMTable m_cmd_to_pwm_lut;

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -37,6 +37,7 @@ namespace thrusters_blue_robotics_t500 {
     protected:
     private:
         uint32_t computePWMCommand(float command) const;
+        uint32_t invertPWMCommand(uint32_t pwm_command) const;
 
         // Properties
         std::uint32_t m_no_actuation_pwm_command = 1500;

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -15,6 +15,7 @@ describe OroGen.thrusters_blue_robotics_t500.Task do
 
         @task.properties.command_to_pwm_table_file_path = command_table_path
         @task.properties.no_actuation_pwm_command = 42
+        @task.properties.center_duty_cycle = 1500
     end
 
     it "raises if cmd_in has different mode than configured" do

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -87,7 +87,7 @@ describe OroGen.thrusters_blue_robotics_t500.Task do
         syskit_configure_and_start(task)
         t0 = Time.now
         pwm_out = expect_execution do
-            syskit_write task.cmd_in_port, effort_command({ a: -16.45 })
+            syskit_write task.cmd_in_port, effort_command({ a: -10.45 })
         end.to do
             have_one_new_sample task.cmd_out_port
         end
@@ -102,7 +102,7 @@ describe OroGen.thrusters_blue_robotics_t500.Task do
         syskit_configure_and_start(task)
         t0 = Time.now
         pwm_out = expect_execution do
-            syskit_write task.cmd_in_port, effort_command({ a: 10.32 })
+            syskit_write task.cmd_in_port, effort_command({ a: 17.32 })
         end.to do
             have_one_new_sample task.cmd_out_port
         end
@@ -174,7 +174,33 @@ describe OroGen.thrusters_blue_robotics_t500.Task do
         assert pwm_out.timestamp > t0
         assert_equal pwm_out.duty_cycles.size, 5
 
-        expected = [1381, 1238, 1449, 1607, 1702]
+        expected = [1411, 1305, 1461, 1647, 1771]
+
+        expected.zip(pwm_out.duty_cycles).each do |true_value, actual|
+            assert_equal true_value, actual
+        end
+    end
+
+    it "allows both commands to go to maximum duty cycle despite the helice alignment" do
+        task.properties.helices_alignment = [helice_alignment(:CLOCKWISE),
+                                             helice_alignment(:COUNTERCLOCKWISE),
+                                             helice_alignment(:CLOCKWISE),
+                                             helice_alignment(:COUNTERCLOCKWISE)]
+        syskit_configure_and_start(task)
+
+        t0 = Time.now
+        pwm_out = expect_execution do
+            syskit_write(task.cmd_in_port,
+                         effort_command({ a: 16.44, b: 16.44,
+                                          c: -10.31, d: -10.31  }))
+        end.to do
+            have_one_new_sample task.cmd_out_port
+        end
+
+        assert pwm_out.timestamp > t0
+        assert_equal pwm_out.duty_cycles.size, 4
+
+        expected = [1100, 1900, 1900, 1100]
 
         expected.zip(pwm_out.duty_cycles).each do |true_value, actual|
             assert_equal true_value, actual

--- a/thrusters_blue_robotics_t500.orogen
+++ b/thrusters_blue_robotics_t500.orogen
@@ -22,7 +22,9 @@ task_context "Task" do
     # The helices can be either Clockwise oriented or Counter Clockwise oriented
     property "helices_alignment", "/std/vector</thrusters_blue_robotics_t500/HeliceAlignment>"
 
-    property "no_actuation_pwm_command", "int", 1500
+    property "center_duty_cycle", "double", 1_500_000
+
+    property "no_actuation_pwm_command", "int", 1_500_000
     property "cmd_in_mode", "/base/JointState/MODE", :EFFORT
 
     input_port "cmd_in", "/base/samples/Joints"


### PR DESCRIPTION
Inverting the effort command would result in one of the motors not achieving acting in a full thrust pwm command. That happens because the effort to pwm table isnt symmetric (effort goes from 16.44 to -10.31).

This was not caught by the existing unit tests because they were using wrong values in the "saturated" tests

<!--
Depends on:
- [ ]

-->
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [x] Write unit tests (when relevant)
- [x] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
