### PR TITLE
feat: add extra output in the new raw_io::PWMDutyDurations type

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -1,13 +1,12 @@
 <package>
   <description brief="Driver for the Blue Robotics T500 thruster">
-
   </description>
   <author>tidewise/wellington.castro@tidewise.io</author>
-  <license></license>
   <url>http://tidewise.io</url>
-  <logo>http://</logo>
+
   <depend package="base/cmake" />
   <depend package="base/orogen/types" />
   <depend package="drivers/orogen/linux_pwms" />
+  <depend package="drivers/orogen/raw_io" />
   <test_depend package="tools/syskit" />
 </package>

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -115,8 +115,12 @@ void Task::updateHook()
     }
 
     linux_pwms::PWMCommand output;
+    raw_io::PWMDutyDurations rawio;
+
     output.timestamp = base::Time::now();
     output.duty_cycles.reserve(cmd_in.size());
+    rawio.time = base::Time::now();
+    rawio.on_durations.reserve(cmd_in.size());
     for (size_t command_counter = 0; command_counter < cmd_in.elements.size();
          command_counter++) {
         auto pwm_command = computePWMCommand(
@@ -125,9 +129,11 @@ void Task::updateHook()
             pwm_command = invertPWMCommand(pwm_command);
         }
         output.duty_cycles.push_back(pwm_command);
+        rawio.on_durations.push_back(pwm_command);
     }
 
     _cmd_out.write(output);
+    _raw_io_pwm_out.write(rawio);
 }
 void Task::errorHook()
 {

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -48,8 +48,6 @@ namespace thrusters_blue_robotics_t500 {
         std::vector<int> m_helices_alignment;
 
     public:
-
-
         /** TaskContext constructor for Task
          * \param name Name of the task. This name needs to be unique to make it
          * identifiable via nameservices. \param initial_state The initial TaskState of

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -155,6 +155,33 @@ describe OroGen.thrusters_blue_robotics_t500.Task do
         end
     end
 
+    it "outputs to the new rawio output as well" do
+        task.properties.helices_alignment = [helice_alignment(:COUNTERCLOCKWISE),
+                                             helice_alignment(:COUNTERCLOCKWISE),
+                                             helice_alignment(:COUNTERCLOCKWISE),
+                                             helice_alignment(:COUNTERCLOCKWISE),
+                                             helice_alignment(:COUNTERCLOCKWISE)]
+        syskit_configure_and_start(task)
+
+        t0 = Time.now
+        pwm_out = expect_execution do
+            syskit_write(task.cmd_in_port,
+                         effort_command({ a: 2.21, b: 6.21,
+                                          c: 0.69, d: -2.86, e: -6.52 }))
+        end.to do
+            have_one_new_sample task.raw_io_pwm_out_port
+        end
+
+        assert pwm_out.time > t0
+        assert_equal pwm_out.on_durations.size, 5
+
+        expected = [1589, 1695, 1539, 1353, 1229]
+
+        expected.zip(pwm_out.on_durations).each do |true_value, actual|
+            assert_equal true_value, actual
+        end
+    end
+
     it "interpolates effort commands with inverted helice" do
         task.properties.helices_alignment = [helice_alignment(:CLOCKWISE),
                                              helice_alignment(:CLOCKWISE),

--- a/thrusters_blue_robotics_t500.orogen
+++ b/thrusters_blue_robotics_t500.orogen
@@ -7,6 +7,7 @@ cxx_standard "c++17"
 import_types_from "thrusters_blue_robotics_t500Types.hpp"
 import_types_from "base"
 import_types_from "linux_pwms"
+import_types_from "raw_io"
 
 # Component for convert an EFFORT command into its respective PWM value
 # Should this task has a timeout? So it zero command if no input is received for the
@@ -30,6 +31,7 @@ task_context "Task" do
     input_port "cmd_in", "/base/samples/Joints"
 
     output_port "cmd_out", "linux_pwms/PWMCommand"
+    output_port "raw_io_pwm_out", "raw_io/PWMDutyDurations"
 
     exception_states :INVALID_COMMAND_MODE, :INVALID_COMMAND_SIZE
 


### PR DESCRIPTION
Keep the old one for backward compatibility
