### PR TITLE
feat: apply a ramp to cmd in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,6 @@ build/*
 *autobuild-stamp
 
 .vscode/*
-
+.jj/*
+bundle/*
+orocos.log

--- a/manifest.xml
+++ b/manifest.xml
@@ -6,6 +6,7 @@
 
   <depend package="base/cmake" />
   <depend package="base/orogen/types" />
+  <depend package="control/control_base" />
   <depend package="drivers/orogen/linux_pwms" />
   <depend package="drivers/orogen/raw_io" />
   <test_depend package="tools/syskit" />

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -2,7 +2,9 @@
 
 #include "Task.hpp"
 #include "Helpers.hpp"
+#include "control_base/RampState.hpp"
 
+using namespace control_base;
 using namespace thrusters_blue_robotics_t500;
 
 Task::Task(std::string const& name)
@@ -27,17 +29,36 @@ bool Task::configureHook()
     m_no_actuation_pwm_command = _no_actuation_pwm_command.get();
     m_cmd_in_mode = _cmd_in_mode.get();
     m_helices_alignment = _helices_alignment.get();
-    m_cmd_to_pwm_lut = std::make_unique<PWMTable>(
-        loadPWMTable(_command_to_pwm_table_file_path.get())
-    );
-    return true;
+    m_cmd_to_pwm_lut =
+        std::make_unique<PWMTable>(loadPWMTable(_command_to_pwm_table_file_path.get()));
+
+    auto size = m_helices_alignment.size();
+    m_ramp_rates = _cmd_ramp.get();
+    if (m_ramp_rates.size() == size) {
+        return true;
+    }
+
+    if (m_ramp_rates.empty()) {
+        m_ramp_rates.resize(size);
+        std::fill(m_ramp_rates.begin(), m_ramp_rates.end(), base::infinity<double>());
+        return true;
+    }
+
+    throw std::invalid_argument("ramp rates and helices aligment vectors differ on size");
 }
+
 bool Task::startHook()
 {
     if (!TaskBase::startHook())
         return false;
+
+    m_ramp_states.resize(m_ramp_rates.size());
+    for (size_t i = 0; i < m_ramp_states.size(); i++) {
+        m_ramp_states[i] = control_base::Ramp(0, m_ramp_rates[i]);
+    }
     return true;
 }
+
 void Task::updateHook()
 {
     TaskBase::updateHook();
@@ -51,10 +72,15 @@ void Task::updateHook()
         return exception(INVALID_COMMAND_SIZE);
     }
 
-    for (auto const& command : cmd_in.elements) {
+    auto now = base::Time::now();
+    for (size_t i = 0; i < cmd_in.elements.size(); i++) {
+        auto& command = cmd_in.elements[i];
         if (command.getMode() != m_cmd_in_mode) {
             return exception(INVALID_COMMAND_MODE);
         }
+        auto& ramp_state = m_ramp_states[i];
+        auto cmd_after_ramp = ramp_state.apply(command.getField(m_cmd_in_mode), now);
+        command.setField(m_cmd_in_mode, cmd_after_ramp);
     }
 
     linux_pwms::PWMCommand output;
@@ -69,8 +95,7 @@ void Task::updateHook()
         auto pwm_command = commandToPWM(
             cmd_in.elements[command_counter].getField(base::JointState::EFFORT),
             *m_cmd_to_pwm_lut,
-            m_no_actuation_pwm_command
-        );
+            m_no_actuation_pwm_command);
 
         if (m_helices_alignment[command_counter] == -1) {
             pwm_command = invertPWMCommand(pwm_command, m_lut_center_duty_cycle);
@@ -81,7 +106,21 @@ void Task::updateHook()
 
     _cmd_out.write(output);
     _raw_io_pwm_out.write(rawio);
+
+    auto ramp_states = getRampStates();
+    _ramp_state.write(ramp_states);
 }
+
+std::vector<control_base::RampState> Task::getRampStates()
+{
+    std::vector<control_base::RampState> states;
+    states.resize(m_ramp_states.size());
+    for (size_t i = 0; i < m_ramp_states.size(); i++) {
+        states[i] = m_ramp_states[i].getState();
+    }
+    return states;
+}
+
 void Task::errorHook()
 {
     TaskBase::errorHook();

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -5,7 +5,10 @@
 
 #include "thrusters_blue_robotics_t500/TaskBase.hpp"
 
+#include "control_base/Ramp.hpp"
+#include "control_base/RampState.hpp"
 #include <base/JointState.hpp>
+#include <base/Time.hpp>
 
 namespace thrusters_blue_robotics_t500 {
     class PWMTable;
@@ -40,6 +43,11 @@ namespace thrusters_blue_robotics_t500 {
 
         std::unique_ptr<PWMTable> m_cmd_to_pwm_lut;
         std::vector<HeliceAlignment> m_helices_alignment;
+
+        std::vector<control_base::Ramp> m_ramp_states;
+        std::vector<double> m_ramp_rates;
+
+        std::vector<control_base::RampState> getRampStates();
 
     public:
         /** TaskContext constructor for Task

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -235,6 +235,51 @@ describe OroGen.thrusters_blue_robotics_t500.Task do
         end
     end
 
+    it "returns the no actuation pwm command on the very first sample of the ramp" do
+        task.properties.helices_alignment = [helice_alignment(:COUNTERCLOCKWISE)]
+        task.properties.cmd_ramp = [5]
+        syskit_configure_and_start(task)
+
+        pwm_out = expect_execution do
+            syskit_write(task.cmd_in_port, effort_command({ a: -9.91 }))
+        end.to do
+            have_one_new_sample task.cmd_out_port
+        end
+        assert_equal 42, pwm_out.duty_cycles.first
+    end
+
+    it "applies a ramp to the joint command" do
+        task.properties.helices_alignment = [helice_alignment(:COUNTERCLOCKWISE)]
+        task.properties.cmd_ramp = [2.5]
+        syskit_configure_and_start(task)
+
+        # This will go to a 0 command
+        pwm_out = expect_execution do
+            syskit_write(task.cmd_in_port, effort_command({ a: -9.91 }))
+        end.to do
+            have_one_new_sample task.cmd_out_port
+        end
+        assert_equal 42, pwm_out.duty_cycles.first
+
+        # Ensure that a minimum time has passed since the last write to actually make a
+        # difference in the ramp
+        sleep 0.1
+
+        pwm_out = expect_execution do
+            syskit_write(task.cmd_in_port, effort_command({ a: 16.24 }))
+        end.to do
+            have_one_new_sample task.cmd_out_port
+        end
+        actual = pwm_out.duty_cycles.first
+        # Checking the exact value is troublesome as it depends on the delta time between
+        # each write. So instead check that the value is between the equivalent PWM
+        # commands.
+        #
+        # Keep in mind that 1520 is the last sample for the 0 command
+        assert_operator actual, :>, 1520
+        assert_operator actual, :<, 1896
+    end
+
     def effort_command(values)
         Types.base.samples.Joints.new(
             time: Time.now,

--- a/thrusters_blue_robotics_t500.orogen
+++ b/thrusters_blue_robotics_t500.orogen
@@ -9,6 +9,9 @@ import_types_from "base"
 import_types_from "linux_pwms"
 import_types_from "raw_io"
 
+using_library "control_base"
+import_types_from "control_base/RampState.hpp"
+
 # Component for convert an EFFORT command into its respective PWM value
 # Should this task has a timeout? So it zero command if no input is received for the
 # given period
@@ -28,10 +31,14 @@ task_context "Task" do
     property "no_actuation_pwm_command", "int", 1_500_000
     property "cmd_in_mode", "/base/JointState/MODE", :EFFORT
 
+    # Maximum allowed variation in input command in unit/s for each thruster
+    property "cmd_ramp", "/std/vector<double>"
+
     input_port "cmd_in", "/base/samples/Joints"
 
     output_port "cmd_out", "linux_pwms/PWMCommand"
     output_port "raw_io_pwm_out", "raw_io/PWMDutyDurations"
+    output_port "ramp_state", "/std/vector<control_base/RampState>"
 
     exception_states :INVALID_COMMAND_MODE, :INVALID_COMMAND_SIZE
 


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/control-control_base/pull/5


# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [ ] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
